### PR TITLE
Fix to show the correct number of points per event when row is expanded

### DIFF
--- a/src/lib/components/ResultsTable.svelte
+++ b/src/lib/components/ResultsTable.svelte
@@ -84,12 +84,12 @@
                 <div class="events-table-header-cell small-screen center">Pts</div>
               </div>
               <div class="events-table-body">
-                {#each events as { eventId, title, startTime, guests, points }}
+                {#each events as { title, startTime, guests, points, pointsAwarded }}
                   <div class="events-table-row">
                     <div>{title}</div>
                     <div>{format(new Date(startTime), 'M/d')}</div>
                     <div>{guests || 0}</div>
-                    <div class="bold">{points}</div>
+                    <div class="bold">{pointsAwarded || points}</div>
                   </div>
                 {/each}
               </div>

--- a/src/lib/modules/types.ts
+++ b/src/lib/modules/types.ts
@@ -56,6 +56,8 @@ export type EventAttendance = {
 	title: string;
 	type: string;
 	points: number;
+	// When awarded by an admin, they'll show up here and we need to use this field instead of points
+	pointsAwarded?: number;
 	name: string;
 	guests: number;
 	names: { name: string; org: string }[];


### PR DESCRIPTION
Fix to show the correct number of points per event when row is expanded